### PR TITLE
Fixed bug in NetSecure_SockRxDataHandler() that caused HTTPsSock_Conn…

### DIFF
--- a/Secure/Segger/net_secure_emssl.c
+++ b/Secure/Segger/net_secure_emssl.c
@@ -1971,7 +1971,7 @@ NET_SOCK_RTN_CODE  NetSecure_SockRxDataHandler (NET_SOCK    *p_sock,
                                                 NET_ERR     *p_err)
 {
     CPU_INT32S          result;
-    CPU_BOOLEAN         rx_q_empty;
+    CPU_BOOLEAN         rx_q_closed;
     NET_SOCK_RTN_CODE   ret_err;
     NET_CONN_ID         tcp_conn_id;
     NET_SOCK_ID         sock_id;
@@ -1980,10 +1980,10 @@ NET_SOCK_RTN_CODE  NetSecure_SockRxDataHandler (NET_SOCK    *p_sock,
     CPU_BOOLEAN         block;
 
 
-    sock_id    = p_sock->ID;
-    rx_q_empty = DEF_FALSE;
-    ret_err    = NET_SOCK_BSD_ERR_RX;
-   *p_err      = NET_SOCK_ERR_NONE;
+    sock_id     = p_sock->ID;
+    rx_q_closed = DEF_FALSE;
+    ret_err     = NET_SOCK_BSD_ERR_RX;
+   *p_err       = NET_SOCK_ERR_NONE;
 
     if (p_sock->SecureSession == (SSL_SESSION *)0) {
        *p_err = NET_SECURE_ERR_NULL_PTR;
@@ -2015,8 +2015,8 @@ NET_SOCK_RTN_CODE  NetSecure_SockRxDataHandler (NET_SOCK    *p_sock,
     }
     if (result < 0) {
         tcp_conn_id =  NetConn_Tbl[p_sock->ID_Conn].ID_Transport;
-        rx_q_empty  = (NetTCP_ConnTbl[tcp_conn_id].RxQ_App_Head == (NET_BUF *)0);
-       (rx_q_empty) ? (*p_err = NET_SOCK_ERR_RX_Q_CLOSED) : (*p_err = NET_ERR_RX);
+        rx_q_closed = (NetTCP_ConnTbl[tcp_conn_id].RxQ_State == NET_TCP_RX_Q_STATE_CLOSED);
+       *p_err       = (rx_q_closed) ? (NET_SOCK_ERR_RX_Q_CLOSED) : (NET_ERR_RX);
     } else {
         ret_err = result;
     }


### PR DESCRIPTION
…DataRx() to erroneously set a secure HTTP connection to a closed state.